### PR TITLE
performance tricks

### DIFF
--- a/AsyncNats/INatsConnection.cs
+++ b/AsyncNats/INatsConnection.cs
@@ -19,6 +19,8 @@
         long ReceiverQueueSize { get; }
         long TransmitBytesTotal { get; }
         long ReceivedBytesTotal { get; }
+        long TransmitMessagesTotal { get; }
+        long ReceivedMessagesTotal { get; }
 
         ValueTask ConnectAsync();
         ValueTask DisconnectAsync();

--- a/AsyncNats/Messages/NatsConnect.cs
+++ b/AsyncNats/Messages/NatsConnect.cs
@@ -62,7 +62,7 @@
             Echo = options.Echo;
         }
 
-        public static IMemoryOwner<byte> RentedSerialize(MemoryPool<byte> pool, NatsConnect msg)
+        public static IMemoryOwner<byte> RentedSerialize(NatsMemoryPool pool, NatsConnect msg)
         {
             var serialized = JsonSerializer.SerializeToUtf8Bytes(msg, new JsonSerializerOptions {IgnoreNullValues = true});
             var hint = _command.Length +

--- a/AsyncNats/Messages/NatsMsg.cs
+++ b/AsyncNats/Messages/NatsMsg.cs
@@ -4,6 +4,7 @@
     using System.Buffers;
     using System.Buffers.Text;
     using System.Net;
+    using System.Runtime.CompilerServices;
     using System.Text;
     using System.Threading;
 
@@ -13,13 +14,33 @@
         private int _referenceCounter;
         private IMemoryOwner<byte>? _rentedPayload;
 
-        public string Subject { get; set; } = string.Empty;
-        public string SubscriptionId { get; set; } = string.Empty;
-        public string ReplyTo { get; set; } = string.Empty;
-        public ReadOnlyMemory<byte> Payload { get; set; } = _empty;
+        public readonly Utf8String Subject;
+        public readonly Utf8String SubscriptionId;
+        public readonly Utf8String ReplyTo;
+        public ReadOnlyMemory<byte> Payload { get; private set; }
+
+        public NatsMsg(in Utf8String subject, in Utf8String subscriptionId, in Utf8String replyTo, ReadOnlyMemory<byte> payload)
+        {
+            Subject = subject;
+            SubscriptionId = subscriptionId;
+            ReplyTo = replyTo;
+            Payload = payload;
+            _rentedPayload = null;
+            _referenceCounter = -1;
+        }
+
+        public NatsMsg(in Utf8String subject,in Utf8String subscriptionId, in Utf8String replyTo, ReadOnlyMemory<byte> payload, IMemoryOwner<byte> rentedPayload)
+        {
+            Subject = subject;
+            SubscriptionId = subscriptionId;
+            ReplyTo = replyTo;
+            Payload = payload;
+            _rentedPayload = rentedPayload;
+            _referenceCounter = 1;
+        }
 
         public void Rent()
-        {
+        {            
             Interlocked.Increment(ref _referenceCounter);
         }
 
@@ -34,33 +55,51 @@
 
         public static INatsServerMessage? ParseMessage(NatsMemoryPool pool, in ReadOnlySpan<byte> line, ref SequenceReader<byte> reader)
         {
-            var next = line.Slice(4); // Remove "MSG "
-            var part = next.Slice(0, next.IndexOf((byte) ' '));
-            var subject = Encoding.ASCII.GetString(part);
-
-            next = next.Slice(part.Length + 1);
-            part = next.Slice(0, next.IndexOf((byte) ' '));
-            var sid = Encoding.ASCII.GetString(part);
-
-            next = next.Slice(part.Length + 1);
-            part = next;
-            var replyTo = string.Empty;
-            var split = next.IndexOf((byte) ' ');
-            if (split > -1)
+            //parse payload size
+            var multiplier = 1;
+            var payloadSize = 0;
+            var payloadSizeStart = line.Length - 1;
+            do
             {
-                part = next.Slice(0, split);
-                replyTo = Encoding.ASCII.GetString(part);
-                part = next.Slice(part.Length + 1);
-            }
+                payloadSize += (line[payloadSizeStart] - '0') * multiplier;
+                multiplier *= 10;
+                payloadSizeStart--;
+            } while (line[payloadSizeStart] != ' ');
 
-            if (!Utf8Parser.TryParse(part, out int payloadSize, out int consumed)) throw new ProtocolViolationException($"Invalid message payload size {Encoding.ASCII.GetString(line)}");
 
             if (reader.Remaining < payloadSize + 2) return null;
 
-            var payload = pool.Rent(payloadSize);
-            reader.Sequence.Slice(reader.Position, payloadSize).CopyTo(payload.Memory.Span);
+            var wholeMessageSize = payloadSize + line.Length;
+            var copyRented = pool.Rent(wholeMessageSize);
+
+            //copy message header
+            var copyMemory = copyRented.Memory;
+            line.CopyTo(copyMemory.Span);
+
+            //copy payload
+            copyMemory = copyRented.Memory.Slice(line.Length);
+            reader.Sequence.Slice(reader.Position, payloadSize).CopyTo(copyMemory.Span);
             reader.Advance(payloadSize + 2);
-            return new NatsMsg {Subject = subject, Payload = payload.Memory, _rentedPayload = payload, ReplyTo = replyTo, SubscriptionId = sid, _referenceCounter = 1};
+            var payload = copyMemory.Slice(0, payloadSize);
+
+            //get pointers from header
+            var next = copyRented.Memory.Slice(4);
+            var part = next.Slice(0, next.Span.IndexOf((byte)' '));
+            var subject = new Utf8String(part, convert: false);
+
+            next = next.Slice(part.Length + 1);
+            part = next.Slice(0, next.Span.IndexOf((byte)' '));
+            var sid = new Utf8String(part, convert: false);
+
+            next = next.Slice(part.Length + 1);
+            var replyTo = Utf8String.Empty;
+            var split = next.Span.IndexOf((byte)' ');
+            if (split > 0)
+            {
+                replyTo = new Utf8String(next.Slice(0, split), convert: false);
+            }
+
+            return new NatsMsg(subject, sid, replyTo, payload, copyRented);
         }
     }
 }

--- a/AsyncNats/Messages/NatsOk.cs
+++ b/AsyncNats/Messages/NatsOk.cs
@@ -5,9 +5,11 @@
 
     public class NatsOk : INatsServerMessage
     {
+        private readonly static NatsOk _instance = new NatsOk();
+
         public static INatsServerMessage? ParseMessage(NatsMemoryPool pool, in ReadOnlySpan<byte> line, ref SequenceReader<byte> reader)
         {
-            return new NatsOk();
+            return _instance;
         }
     }
 }

--- a/AsyncNats/Messages/NatsPing.cs
+++ b/AsyncNats/Messages/NatsPing.cs
@@ -20,7 +20,7 @@
             return new NatsPing();
         }
 
-        public static IMemoryOwner<byte> RentedSerialize(MemoryPool<byte> pool)
+        public static IMemoryOwner<byte> RentedSerialize(NatsMemoryPool pool)
         {
             return _command; 
         }

--- a/AsyncNats/Messages/NatsPing.cs
+++ b/AsyncNats/Messages/NatsPing.cs
@@ -8,11 +8,11 @@
 
     public class NatsPing : INatsServerMessage, INatsClientMessage
     {
-        private static readonly ReadOnlyMemory<byte> _command = new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes("PING\r\n"));
+        private static readonly NoOwner<byte> _command = new NoOwner<byte>(Encoding.UTF8.GetBytes("PING\r\n"));
 
         public async ValueTask Serialize(PipeWriter writer)
         {
-            await writer.WriteAsync(_command);
+            await writer.WriteAsync(_command.Memory);
         }
 
         public static INatsServerMessage? ParseMessage(NatsMemoryPool pool, in ReadOnlySpan<byte> line, ref SequenceReader<byte> reader)
@@ -22,9 +22,7 @@
 
         public static IMemoryOwner<byte> RentedSerialize(MemoryPool<byte> pool)
         {
-            var buffer = pool.Rent(_command.Length);
-            _command.CopyTo(buffer.Memory);
-            return buffer;
+            return _command; 
         }
     }
 }

--- a/AsyncNats/Messages/NatsPong.cs
+++ b/AsyncNats/Messages/NatsPong.cs
@@ -8,11 +8,12 @@
 
     public class NatsPong : INatsServerMessage, INatsClientMessage
     {
-        private static readonly ReadOnlyMemory<byte> _command = new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes("PONG\r\n"));
+
+        private static readonly NoOwner<byte> _command = new NoOwner<byte>(Encoding.UTF8.GetBytes("PONG\r\n"));
 
         public async ValueTask Serialize(PipeWriter writer)
         {
-            await writer.WriteAsync(_command);
+            await writer.WriteAsync(_command.Memory);
         }
 
         public static INatsServerMessage ParseMessage(NatsMemoryPool pool, in ReadOnlySpan<byte> line, ref SequenceReader<byte> reader)
@@ -20,11 +21,9 @@
             return new NatsPong();
         }
 
-        public static IMemoryOwner<byte> RentedSerialize(MemoryPool<byte> pool)
+        public static IMemoryOwner<byte> RentedSerialize(NatsMemoryPool pool)
         {
-            var buffer = pool.Rent(_command.Length);
-            _command.CopyTo(buffer.Memory);
-            return buffer;
+            return _command;
         }
     }
 }

--- a/AsyncNats/Messages/NatsSub.cs
+++ b/AsyncNats/Messages/NatsSub.cs
@@ -21,12 +21,12 @@
             await writer.WriteAsync(Encoding.UTF8.GetBytes($"SUB {Subject} {(string.IsNullOrEmpty(QueueGroup) ? "" : $"{QueueGroup} ")}{SubscriptionId}\r\n"));
         }
 
-        public static IMemoryOwner<byte> RentedSerialize(NatsMemoryPool pool, string subject, string? queueGroup, string subscriptionId)
+        public static IMemoryOwner<byte> RentedSerialize(NatsMemoryPool pool, Utf8String subject, Utf8String queueGroup, Utf8String subscriptionId)
         {
             var length = _command.Length;
-            length += subject.Length + 1;
-            length += queueGroup?.Length + 1 ?? 0;
-            length += subscriptionId.Length;
+            length += subject.Memory.Length + 1;
+            length += queueGroup.Memory.Length>0? queueGroup.Memory.Length+1:0;
+            length += subscriptionId.Memory.Length;
             length += _end.Length;
 
             var rented = pool.Rent(length);
@@ -34,17 +34,22 @@
 
             _command.CopyTo(buffer);
             var consumed = _command.Length;
-            consumed += Encoding.UTF8.GetBytes(subject, buffer.Slice(consumed).Span);
+
+            subject.Memory.Span.CopyTo(buffer.Slice(consumed).Span);
+            consumed += subject.Memory.Length;
+
             _del.CopyTo(buffer.Slice(consumed));
             consumed += _del.Length;
-            if (!string.IsNullOrEmpty(queueGroup))
+            if (!queueGroup.IsEmpty)
             {
-                consumed += Encoding.UTF8.GetBytes(queueGroup, buffer.Slice(consumed).Span);
+                queueGroup.Memory.Span.CopyTo(buffer.Slice(consumed).Span);
+                consumed += subscriptionId.Memory.Length;                                
                 _del.CopyTo(buffer.Slice(consumed));
                 consumed += _del.Length;
             }
 
-            consumed += Encoding.UTF8.GetBytes(subscriptionId, buffer.Slice(consumed).Span);
+            subscriptionId.Memory.Span.CopyTo(buffer.Slice(consumed).Span);
+            consumed += subscriptionId.Memory.Length;
             _end.CopyTo(buffer.Slice(consumed));
             
             return rented;

--- a/AsyncNats/NatsRequestResponse.cs
+++ b/AsyncNats/NatsRequestResponse.cs
@@ -51,7 +51,7 @@ namespace EightyDecibel.AsyncNats
                     var subscription = _connection.Subscribe($"{_subject}.>", cancellationToken: cancellationToken);
                     await foreach (var message in subscription.WithCancellation(cancellationToken))
                     {
-                        if (!_responseHandlers.TryRemove(message.Subject, out var handler))
+                        if (!_responseHandlers.TryRemove(message.Subject.AsString(), out var handler))
                             continue;
 
                         handler(message);

--- a/AsyncNats/Rpc/NatsServerProxy.cs
+++ b/AsyncNats/Rpc/NatsServerProxy.cs
@@ -64,7 +64,7 @@ namespace EightyDecibel.AsyncNats.Rpc
                 msg.Rent();
                 try
                 {
-                    var method = msg.Subject.Substring((_subject ?? string.Empty).Length - 1);
+                    var method = msg.Subject.AsString().Substring((_subject ?? string.Empty).Length - 1);
                     if (_asyncMethods.TryGetValue(method, out var delegates))
                     {
                         if (taskFactory == null) await InvokeAsync(method, delegates.invoke, delegates.serialize, msg, cancellationToken);
@@ -103,20 +103,20 @@ namespace EightyDecibel.AsyncNats.Rpc
             try
             {
                 var response = invoke(msg.Payload);
-                if (!string.IsNullOrEmpty(msg.ReplyTo))
-                    await _parent.PublishAsync(msg.ReplyTo, response, cancellationToken: cancellationToken);
+                if (!string.IsNullOrEmpty(msg.ReplyTo.AsString()))
+                    await _parent.PublishAsync(msg.ReplyTo.AsString(), response, cancellationToken: cancellationToken);
             }
             catch (Exception ex)
             {
                 _logger?.LogWarning(ex, "{Method} threw an exception", method);
 
-                if (!string.IsNullOrEmpty(msg.ReplyTo))
+                if (!string.IsNullOrEmpty(msg.ReplyTo.AsString()))
                 {
                     await using var ms = new MemoryStream();
                     var formatter = new BinaryFormatter();
                     formatter.Serialize(ms, ex);
 
-                    await _parent.PublishObjectAsync(msg.ReplyTo, new NatsServerResponse {E = ms.ToArray()}, cancellationToken: cancellationToken);
+                    await _parent.PublishObjectAsync(msg.ReplyTo.AsString(), new NatsServerResponse {E = ms.ToArray()}, cancellationToken: cancellationToken);
                 }
 
                 _parent.ServerException(this, msg, ex);
@@ -135,20 +135,20 @@ namespace EightyDecibel.AsyncNats.Rpc
                 var task = invoke(msg.Payload);
                 await task;
                 var response = serialize(task);
-                if (!string.IsNullOrEmpty(msg.ReplyTo))
-                    await _parent.PublishAsync(msg.ReplyTo, response, cancellationToken: cancellationToken);
+                if (!string.IsNullOrEmpty(msg.ReplyTo.AsString()))
+                    await _parent.PublishAsync(msg.ReplyTo.AsString(), response, cancellationToken: cancellationToken);
             }
             catch (Exception ex)
             {
                 _logger?.LogWarning(ex, "{Method} threw an exception", method);
 
-                if (!string.IsNullOrEmpty(msg.ReplyTo))
+                if (!string.IsNullOrEmpty(msg.ReplyTo.AsString()))
                 {
                     await using var ms = new MemoryStream();
                     var formatter = new BinaryFormatter();
                     formatter.Serialize(ms, ex);
 
-                    await _parent.PublishObjectAsync(msg.ReplyTo, new NatsServerResponse { E = ms.ToArray() }, cancellationToken: cancellationToken);
+                    await _parent.PublishObjectAsync(msg.ReplyTo.AsString(), new NatsServerResponse { E = ms.ToArray() }, cancellationToken: cancellationToken);
                 }
 
                 _parent.ServerException(this, msg, ex);

--- a/EightyDecibel.AsyncNats.sln
+++ b/EightyDecibel.AsyncNats.sln
@@ -23,6 +23,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InterfaceAsyncNatsSample", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LatencyAsyncNatsSample", "LatencyAsyncNatsSample\LatencyAsyncNatsSample.csproj", "{B041A048-1B70-41A0-9090-658090D8BDB5}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SimpleBenchmark", "SimpleBenchmark\SimpleBenchmark.csproj", "{E4E3DEA4-8686-4A26-9A58-1DD68F400DA0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +59,10 @@ Global
 		{B041A048-1B70-41A0-9090-658090D8BDB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B041A048-1B70-41A0-9090-658090D8BDB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B041A048-1B70-41A0-9090-658090D8BDB5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E4E3DEA4-8686-4A26-9A58-1DD68F400DA0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E4E3DEA4-8686-4A26-9A58-1DD68F400DA0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E4E3DEA4-8686-4A26-9A58-1DD68F400DA0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E4E3DEA4-8686-4A26-9A58-1DD68F400DA0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -69,6 +75,7 @@ Global
 		{52FC10C7-BBF2-4C5B-8FEA-AA9A79BF284D} = {2AB7A94E-F3F6-4DA9-975C-3F4D026C1CEF}
 		{0107099C-A20A-4118-A910-9AE23F4D58DE} = {2AB7A94E-F3F6-4DA9-975C-3F4D026C1CEF}
 		{B041A048-1B70-41A0-9090-658090D8BDB5} = {2AB7A94E-F3F6-4DA9-975C-3F4D026C1CEF}
+		{E4E3DEA4-8686-4A26-9A58-1DD68F400DA0} = {2AB7A94E-F3F6-4DA9-975C-3F4D026C1CEF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E5462DB8-9C99-488A-9E2D-D7605CDB80CE}

--- a/LatencyAsyncNatsSample/Program.cs
+++ b/LatencyAsyncNatsSample/Program.cs
@@ -60,6 +60,7 @@
                 Console.Write($"\rMessages processed {_timings.Count} ({_timings.Count / ((Stopwatch.GetTimestamp() - _started) / frequency):N2} messages/sec)  {readerConnection.ReceiverQueueSize}           ");
                 await Task.Delay(1000, cancellation.Token);
             }
+            Console.ReadKey();
 
             cancellation.Cancel();
 
@@ -92,6 +93,8 @@
             Console.WriteLine($"99.999: {_timings[(int)(_timings.Count * 0.99999)] / ms:N2}ms");
             Console.WriteLine($"99.9999: {_timings[(int)(_timings.Count * 0.999999)] / ms:N2}ms");
             Console.WriteLine($"99.99999: {_timings[(int)(_timings.Count * 0.9999999)] / ms:N2}ms");
+
+            Console.ReadKey();
         }
 
         static async Task Reader(NatsConnection connection, CancellationToken cancellationToken)

--- a/SimpleBenchmark/Program.cs
+++ b/SimpleBenchmark/Program.cs
@@ -5,6 +5,7 @@
     using System.Diagnostics;
     using System.Diagnostics.Metrics;
     using System.Linq;
+    using System.Runtime.InteropServices;
     using System.Text.Json;
     using System.Threading;
     using System.Threading.Tasks;
@@ -17,13 +18,14 @@
 
             var messageSizes = new[] { 8, 16, 32, 64, 128, 256, 512, 1024 };
 
-
             foreach(var messageSize in messageSizes)
             {
-                await RunBenchmark(1, 0, messageSize);
-                await RunBenchmark(1, 1, messageSize);
-                await RunBenchmark(2, 1, messageSize);
-                await RunBenchmark(2, 2, messageSize);                
+                foreach(var rate in new[] { 10_000, 100_000, 500_000,750_000 })
+                {
+                    await RunBenchmark(1, 0, messageSize, rate);
+                    await RunBenchmark(1, 1, messageSize, rate);
+                    await RunBenchmark(2, 1, messageSize, rate);
+                }
                 Console.WriteLine();
             }
 
@@ -33,10 +35,10 @@
         }
 
 
-        static async Task RunBenchmark(int publishers,int subscribers,int messageSize)
+        static async Task RunBenchmark(int publishers,int subscribers,int messageSize,int msgPerSecond)
         {
 
-            Console.Write($"{messageSize} B\t{publishers} pub\t{subscribers} sub\t:\t");
+            Console.Write($"Target {(msgPerSecond>0?(msgPerSecond / 1000).ToString()+ "k msg/s" : "flood")}\t{messageSize} B\t{publishers} pub\t{subscribers} sub\t:\t");
 
             var options = new NatsDefaultOptions();
 
@@ -77,11 +79,10 @@
 
 
             List<Task> writers = new List<Task>();
-            List<Task> readers = new List<Task>();
-
+            List<Task<(long count, long sum, long max, long min)>> readers = new List<Task<(long count, long sum, long max, long min)>>();
             foreach(var i in Enumerable.Range(0, publishers))
             {
-                var task = WriterTask(writerConnection, writerCts.Token);
+                var task = WriterTask(writerConnection, (double)msgPerSecond/ publishers, writerCts.Token);
                 writers.Add(task);
             }
 
@@ -94,13 +95,20 @@
             double messagesPerSecond = 0;
             double bytesPerSecond = 0;
 
+            double latencyMean = 0;
+            double latencyMax = 0;
+            double latencyMin = 0;
+
             if (subscribers > 0)
             {
-                //wait 10M messages
+                
                 var sw = Stopwatch.StartNew();
 
-                while (writerConnection.TransmitMessagesTotal < 10_000_000)
-                    await Task.Delay(250);
+                //wait 10M messages
+                //while (writerConnection.TransmitMessagesTotal < 10_000_000)
+                //    await Task.Delay(250);
+
+                await Task.Delay(TimeSpan.FromSeconds(10));
 
                 writerCts.Cancel(); //stop writing
 
@@ -121,16 +129,28 @@
 
                 messagesPerSecond = totalMessages / totalSecondsElapsed;
                 bytesPerSecond= totalBytes / totalSecondsElapsed;
+
+                await Task.WhenAll(readers);
+                latencyMean = readers.Select(r => r.Result.sum).Sum() / readers.Select(r => r.Result.count).Sum();
+                latencyMax = readers.Select(r => r.Result.max).Max();
+                latencyMin = readers.Select(r => r.Result.min).Max();
+
+                var ms = Stopwatch.Frequency / 1000d;
+                latencyMean = latencyMean / ms;
+                latencyMax = latencyMax / ms;
+                latencyMin = latencyMin / ms;
+
             }
             else
             {
                 //get writer only
 
-                //wait 10M messages
                 var sw = Stopwatch.StartNew();
 
-                while (writerConnection.TransmitMessagesTotal < 10_000_000)
-                    await Task.Delay(250);
+                await Task.Delay(TimeSpan.FromSeconds(10));
+
+                //while (writerConnection.TransmitMessagesTotal < 10_000_000)
+                //    await Task.Delay(250);
 
                 writerCts.Cancel();
 
@@ -147,7 +167,7 @@
                 bytesPerSecond = totalBytes / totalSecondsElapsed;
             }
 
-            Console.Write($"{messagesPerSecond / 1000:f2}k msg/s\t{bytesPerSecond / 1000_0000:f2} MB/s");
+            Console.Write($"{messagesPerSecond / 1000:f1}k msg/s\t{bytesPerSecond / 1000_0000:f2} MB/s Latency: {latencyMean:f2}ms {latencyMax:f2}ms {latencyMin:f2}ms");
             Console.Write("\r\n");
 
             await Task.WhenAll(writers);
@@ -157,25 +177,65 @@
             await writerConnection.DisposeAsync();
 
 
-            async Task WriterTask(NatsConnection connection, CancellationToken cancellationToken)
+            async Task WriterTask(NatsConnection connection, double msgPerSecond, CancellationToken cancellationToken)
             {
                 await Task.Yield();
                 var message = new byte[messageSize];
 
+                var batch = msgPerSecond >= 500_000 ? 100 : msgPerSecond>=100_000?10:1;
+                var delay = msgPerSecond > 0 ? (long)(Stopwatch.Frequency * batch / msgPerSecond) : 0;
+
+                var adjustment = 0L;
+
                 while (!cancellationToken.IsCancellationRequested)
-                {
-                    await connection.PublishMemoryAsync("benchmark", message, cancellationToken: CancellationToken.None);
+                {                    
+                    var now = Stopwatch.GetTimestamp();
+
+                    BitConverter.TryWriteBytes(message, now);
+
+                    for(var i = batch-1; i >= 0; i--)
+                    {
+                        await connection.PublishMemoryAsync("benchmark", message, cancellationToken: CancellationToken.None);                        
+                    }
+
+                    if (delay ==0) continue;
+
+                    var elapsed = Stopwatch.GetTimestamp() - now;
+
+                    var target = delay + adjustment;
+                    while (elapsed< target)
+                    {
+                        await Task.Yield();
+                        elapsed = Stopwatch.GetTimestamp() - now;                    
+                    }
+                    adjustment = (long)((delay-elapsed));
                 }
             }
 
-            async Task ReaderText(NatsConnection connection, CancellationToken cancellationToken)
+            async Task<(long count,long sum,long max,long min)> ReaderText(NatsConnection connection, CancellationToken cancellationToken)
             {
+
                 await Task.Yield();
+
+                long count = 0;
+                long sum = 0;
+                long max = 0;
+                long min = long.MaxValue;
+
                 try
                 {
                     await foreach (var message in connection.SubscribeUnsafe("benchmark", cancellationToken: cancellationToken))
                     {
-                        //just drop
+
+                        var timestamp=BitConverter.ToInt64(message.Payload.Span);
+
+                        var now = Stopwatch.GetTimestamp();
+                        var rtt= (now - timestamp);
+                        sum += rtt;
+                        count++;
+                        max = Math.Max(rtt, max);
+                        min = Math.Min(rtt, min);
+
                         message.Release();
                     }
                 }
@@ -183,7 +243,8 @@
                 {
                     //swallow
                 }
-                
+
+                return (count,sum, max, min);
 
             }
         }

--- a/SimpleBenchmark/Program.cs
+++ b/SimpleBenchmark/Program.cs
@@ -1,0 +1,191 @@
+﻿namespace SimpleBenchmark
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Diagnostics.Metrics;
+    using System.Linq;
+    using System.Text.Json;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using EightyDecibel.AsyncNats;
+
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+
+            var messageSizes = new[] { 8, 16, 32, 64, 128, 256, 512, 1024 };
+
+
+            foreach(var messageSize in messageSizes)
+            {
+                await RunBenchmark(1, 0, messageSize);
+                await RunBenchmark(1, 1, messageSize);
+                await RunBenchmark(2, 1, messageSize);
+                await RunBenchmark(2, 2, messageSize);                
+                Console.WriteLine();
+            }
+
+            Console.WriteLine();
+            Console.WriteLine("Press any key to exit...");
+            Console.ReadKey();
+        }
+
+
+        static async Task RunBenchmark(int publishers,int subscribers,int messageSize)
+        {
+
+            Console.Write($"{messageSize} B\t{publishers} pub\t{subscribers} sub\t:\t");
+
+            var options = new NatsDefaultOptions();
+
+            var writerConnection = new NatsConnection(options);           
+            var readerConnection = new NatsConnection(options);
+            
+            var writerCts = new CancellationTokenSource();
+            var readerCts = new CancellationTokenSource();
+
+            await writerConnection.ConnectAsync();
+            await readerConnection.ConnectAsync();
+
+            var count = 0;
+            while (writerConnection.Status != NatsStatus.Connected)
+            {
+                await Task.Delay(50);
+                count++;
+                if (count > 100)
+                {
+                    Console.WriteLine("Could not connect to nats server");
+                    await writerConnection.DisposeAsync();
+                    await readerConnection.DisposeAsync();
+                    return;
+                }
+            }
+            while (readerConnection.Status != NatsStatus.Connected)
+            {
+                await Task.Delay(50);
+                count++;
+                if (count > 100)
+                {
+                    Console.WriteLine("Could not connect to nats server");
+                    await writerConnection.DisposeAsync();
+                    await readerConnection.DisposeAsync();
+                    return;
+                }
+            }
+
+
+            List<Task> writers = new List<Task>();
+            List<Task> readers = new List<Task>();
+
+            foreach(var i in Enumerable.Range(0, publishers))
+            {
+                var task = WriterTask(writerConnection, writerCts.Token);
+                writers.Add(task);
+            }
+
+            foreach (var i in Enumerable.Range(0, subscribers))
+            {
+                var task = ReaderText(readerConnection, readerCts.Token);
+                readers.Add(task);
+            }
+
+            double messagesPerSecond = 0;
+            double bytesPerSecond = 0;
+
+            if (subscribers > 0)
+            {
+                //wait 10M messages
+                var sw = Stopwatch.StartNew();
+
+                while (writerConnection.TransmitMessagesTotal < 10_000_000)
+                    await Task.Delay(250);
+
+                writerCts.Cancel(); //stop writing
+
+                //wait complete flush
+                while (writerConnection.SenderQueueSize > 0)
+                    await Task.Delay(50);
+
+                while (readerConnection.ReceiverQueueSize > 0)
+                    await Task.Delay(50);
+
+                readerCts.Cancel(); //stop reading
+
+                sw.Stop();
+
+                var totalMessages = readerConnection.ReceivedMessagesTotal;
+                var totalBytes = readerConnection.ReceivedBytesTotal;
+                var totalSecondsElapsed = sw.Elapsed.TotalSeconds;
+
+                messagesPerSecond = totalMessages / totalSecondsElapsed;
+                bytesPerSecond= totalBytes / totalSecondsElapsed;
+            }
+            else
+            {
+                //get writer only
+
+                //wait 10M messages
+                var sw = Stopwatch.StartNew();
+
+                while (writerConnection.TransmitMessagesTotal < 10_000_000)
+                    await Task.Delay(250);
+
+                writerCts.Cancel();
+
+                while (writerConnection.SenderQueueSize > 0)
+                    await Task.Delay(50);
+
+                sw.Stop();
+
+                var totalMessages = writerConnection.TransmitMessagesTotal;
+                var totalBytes= writerConnection.TransmitBytesTotal;
+                var totalSecondsElapsed = sw.Elapsed.TotalSeconds;
+
+                messagesPerSecond = totalMessages / totalSecondsElapsed;
+                bytesPerSecond = totalBytes / totalSecondsElapsed;
+            }
+
+            Console.Write($"{messagesPerSecond / 1000:f2}k msg/s\t{bytesPerSecond / 1000_0000:f2} MB/s");
+            Console.Write("\r\n");
+
+            await Task.WhenAll(writers);
+            await Task.WhenAll(readers);
+
+            await readerConnection.DisposeAsync();
+            await writerConnection.DisposeAsync();
+
+
+            async Task WriterTask(NatsConnection connection, CancellationToken cancellationToken)
+            {
+                await Task.Yield();
+                var message = new byte[messageSize];
+
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    await connection.PublishMemoryAsync("benchmark", message, cancellationToken: CancellationToken.None);
+                }
+            }
+
+            async Task ReaderText(NatsConnection connection, CancellationToken cancellationToken)
+            {
+                await Task.Yield();
+                try
+                {
+                    await foreach (var message in connection.SubscribeUnsafe("benchmark", cancellationToken: cancellationToken))
+                    {
+                        //just drop
+                        message.Release();
+                    }
+                }
+                catch(OperationCanceledException ex)
+                {
+                    //swallow
+                }
+                
+
+            }
+        }
+    }
+}

--- a/SimpleBenchmark/SimpleBenchmark.csproj
+++ b/SimpleBenchmark/SimpleBenchmark.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <AssemblyName>EightyDecibel.SimpleAsyncNatsSample</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AsyncNats\AsyncNats.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Here I'm adding a few tricks, mainly reducing allocations and virtual calls.
Also adding a benchmark project to try understand where the bottlenecks are at various use cases.

So far, here is where it stands :
![image](https://user-images.githubusercontent.com/840042/185003170-635bd38d-8b92-4257-b3d9-e46959d030e8.png)

It seems that we can flush data to NATS easily at 2M messages/second, but reading is imbalanced. 
I'm also puzzled as why bigger messages seem to perform better. My guess so far is at flow control.


Let me know your thoughts @80dB 